### PR TITLE
forward fraction lost from subscriber to publisher

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -579,6 +579,11 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 	if len(fwdPkts) > 0 {
 		d.receiver.SendRTCP(fwdPkts)
 	}
+
+	// only forward audio track's fractionlost to publiser
+	if d.Kind() == webrtc.RTPCodecTypeAudio {
+		d.receiver.HandleDownTrackFractionLost(maxRatePacketLoss)
+	}
 }
 
 func (d *DownTrack) handleLayerChange(maxRatePacketLoss uint8, expectedMinBitrate uint64) {

--- a/pkg/sfu/router.go
+++ b/pkg/sfu/router.go
@@ -163,6 +163,9 @@ func (r *router) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.TrackRe
 			}
 			r.deleteReceiver(trackID, uint32(track.SSRC()))
 		})
+		recv.OnFractionLostFB(func(lost uint8) {
+			buff.SetLastFractionLostReport(lost)
+		})
 		publish = true
 	}
 


### PR DESCRIPTION
signal to publisher to update Opus OPUS_SET_PACKET_LOSS_PERC when one of the subscribers are experiencing high loss. (requires proxying the highest maxFractionLost from all subscribers to the publisher)